### PR TITLE
SYS-5870 Use shared renovate preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>aptvision/renovate-config"
+  ]
+}


### PR DESCRIPTION
Adopts the shared Renovate preset from
[`aptvision/renovate-config`](https://github.com/aptvision/renovate-config)
so dependency policy lives in one place instead of being copied per repo.

```json
{
  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
  "extends": ["github>aptvision/renovate-config"]
}
```

## Why this preset

Detected dependency manifests in this repo: `gha`, `npm`.

No `clusters/` directory, so the plain `default` preset applies (the `:k8s`
variant only adds Flux manager patterns for cluster repos).

## Policy this applies

| Update | PR? | Automerged | Cooldown |
| --- | --- | --- | --- |
| Third party minor/patch | yes | on green CI | 21 days |
| Third party major | yes | no, human decides | 21 days |
| Internal `aptvision/*` minor/patch | yes | on green CI | none |
| Internal `aptvision/*` major | yes | no, human decides | none |

## Note

The automerge rules assume CI exists and gates merges. If this repo has no
required status checks, minor/patch bumps would merge unvalidated — the preset
README documents a per-repo override for that case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)